### PR TITLE
Switch the Checkov step to soft-fail

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,3 +4,4 @@ steps:
   - label: ':lock: security - checkov'
     command: .buildkite/ci-checkov.sh
     agents: { queue: standard }
+    soft_fail: true


### PR DESCRIPTION
Until we can move to using a pinned Checkov image version – the lack of image
pinning is causing the build step to break unpredictably.